### PR TITLE
Override px width for medium screens

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,12 @@ module.exports = {
   purge: ["./src/**/*.{js,jsx}"],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+      md: '930px',
+    }
+  }
+    
   },
   variants: {
     extend: {},


### PR DESCRIPTION
Fixing styles for medium screens. The best solution I found in order to not break existing behavior is to override px width for medium screens via tailwind config file (default is 768px)

Fixes #3 

Before:

![image](https://user-images.githubusercontent.com/48018975/193694985-fc88c880-d7b0-4d70-9f52-de1357924f60.png)


Now:

![image](https://user-images.githubusercontent.com/48018975/193694850-9288ede6-8e63-4d1c-b582-626da34c16f4.png)
